### PR TITLE
Add navigation tabs and quake history feed

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
@@ -27,10 +27,13 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import androidx.viewpager2.widget.ViewPager2
 import androidx.work.*
 import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.google.android.material.navigation.NavigationBarView
 import io.heckel.ntfy.BuildConfig
 import io.heckel.ntfy.R
 import io.heckel.ntfy.app.Application
@@ -43,12 +46,19 @@ import io.heckel.ntfy.msg.DownloadType
 import io.heckel.ntfy.msg.NotificationDispatcher
 import io.heckel.ntfy.service.SubscriberService
 import io.heckel.ntfy.service.SubscriberServiceManager
+import io.heckel.ntfy.ui.history.EarthquakeReport
+import io.heckel.ntfy.ui.history.QuakeHistoryAdapter
 import io.heckel.ntfy.util.*
 import io.heckel.ntfy.work.DeleteWorker
 import io.heckel.ntfy.work.PollWorker
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import org.json.JSONObject
 import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.random.Random
@@ -67,12 +77,31 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
     private lateinit var mainListContainer: SwipeRefreshLayout
     private lateinit var adapter: MainAdapter
     private lateinit var fab: FloatingActionButton
+    private lateinit var viewPager: ViewPager2
+    private lateinit var navigationBar: NavigationBarView
+    private lateinit var pagerAdapter: MainPagerAdapter
+    private var alertsPageView: View? = null
+    private var historyAdapter: QuakeHistoryAdapter? = null
+    private var historySwipeRefresh: SwipeRefreshLayout? = null
+    private var historyLoadingView: View? = null
+    private var historyStatusText: TextView? = null
+    private var alertsPageInitialized = false
+    private var historyInitialized = false
+    private var isLoadingHistory = false
 
     // Other stuff
     private var actionMode: ActionMode? = null
     private var workManager: WorkManager? = null // Context-dependent
     private var dispatcher: NotificationDispatcher? = null // Context-dependent
     private var appBaseUrl: String? = null // Context-dependent
+    private val historyClient by lazy {
+        OkHttpClient.Builder()
+            .callTimeout(15, TimeUnit.SECONDS)
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .writeTimeout(15, TimeUnit.SECONDS)
+            .build()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -89,51 +118,48 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
         // Action bar
         title = getString(R.string.main_action_bar_title)
 
-        // Floating action button ("+")
-        fab = findViewById(R.id.fab)
-        fab.hide()
-        fab.isEnabled = false
-        fab.isClickable = false
-        fab.visibility = View.GONE
-
-        // Swipe to refresh
-        mainListContainer = findViewById(R.id.main_subscriptions_list_container)
-        mainListContainer.setOnRefreshListener { refreshAllSubscriptions() }
-        mainListContainer.setColorSchemeResources(Colors.refreshProgressIndicator)
-
-        // Update main list based on viewModel (& its datasource/livedata)
-        val noEntries: View = findViewById(R.id.main_no_subscriptions)
-        val onSubscriptionClick = { s: Subscription -> onSubscriptionItemClick(s) }
-        val onSubscriptionLongClick = { s: Subscription -> onSubscriptionItemLongClick(s) }
-
-        mainList = findViewById(R.id.main_subscriptions_list)
-        adapter = MainAdapter(repository, onSubscriptionClick, onSubscriptionLongClick)
-        mainList.adapter = adapter
-
-        viewModel.list().observe(this) {
-            it?.let { subscriptions ->
-                // Update main list
-                adapter.submitList(subscriptions as MutableList<Subscription>)
-                if (it.isEmpty()) {
-                    mainListContainer.visibility = View.GONE
-                    noEntries.visibility = View.VISIBLE
-                } else {
-                    mainListContainer.visibility = View.VISIBLE
-                    noEntries.visibility = View.GONE
-                }
-
-                // Add scrub terms to log (in case it gets exported)
-                subscriptions.forEach { s ->
-                    Log.addScrubTerm(shortUrl(s.baseUrl), Log.TermType.Domain)
-                    Log.addScrubTerm(s.topic)
-                }
-
-                // Update battery banner + WebSocket banner + websocket reconnect banner
-                showHideBatteryBanner(subscriptions)
-                showHideWebSocketBanner(subscriptions)
-                showHideWebSocketReconnectBanner(subscriptions)
+        viewPager = findViewById(R.id.main_view_pager)
+        navigationBar = findViewById(R.id.main_bottom_navigation)
+        pagerAdapter = MainPagerAdapter(
+            layoutInflater,
+            listOf(R.layout.main_page_quake_alerts, R.layout.main_page_quake_history)
+        ) { position, view ->
+            when (position) {
+                0 -> initializeAlertsPage(view)
+                1 -> initializeHistoryPage(view)
             }
         }
+        viewPager.adapter = pagerAdapter
+        viewPager.offscreenPageLimit = pagerAdapter.itemCount
+
+        navigationBar.setOnItemSelectedListener { item ->
+            when (item.itemId) {
+                R.id.nav_alerts -> {
+                    viewPager.setCurrentItem(0, true)
+                    true
+                }
+                R.id.nav_history -> {
+                    viewPager.setCurrentItem(1, true)
+                    maybeLoadHistory()
+                    true
+                }
+                else -> false
+            }
+        }
+        navigationBar.selectedItemId = R.id.nav_alerts
+
+        viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                super.onPageSelected(position)
+                val menuItem = navigationBar.menu.getItem(position)
+                if (!menuItem.isChecked) {
+                    menuItem.isChecked = true
+                }
+                if (position == 1) {
+                    maybeLoadHistory()
+                }
+            }
+        })
 
         // Add scrub terms to log (in case it gets exported) // FIXME this should be in Log.getFormatted
         repository.getUsersLiveData().observe(this) {
@@ -159,75 +185,6 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
             SubscriberServiceManager.refresh(this)
         }
 
-        // Battery banner
-        val batteryBanner = findViewById<View>(R.id.main_banner_battery) // Banner visibility is toggled in onResume()
-        val dontAskAgainButton = findViewById<Button>(R.id.main_banner_battery_dontaskagain)
-        val askLaterButton = findViewById<Button>(R.id.main_banner_battery_ask_later)
-        val fixNowButton = findViewById<Button>(R.id.main_banner_battery_fix_now)
-        dontAskAgainButton.setOnClickListener {
-            batteryBanner.visibility = View.GONE
-            repository.setBatteryOptimizationsRemindTime(Repository.BATTERY_OPTIMIZATIONS_REMIND_TIME_NEVER)
-        }
-        askLaterButton.setOnClickListener {
-            batteryBanner.visibility = View.GONE
-            repository.setBatteryOptimizationsRemindTime(System.currentTimeMillis() + ONE_DAY_MILLIS)
-        }
-        fixNowButton.setOnClickListener {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                val intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
-                startActivity(intent)
-            }
-        }
-
-        // WebSocket banner
-        val wsBanner = findViewById<View>(R.id.main_banner_websocket) // Banner visibility is toggled in onResume()
-        val wsText = findViewById<TextView>(R.id.main_banner_websocket_text)
-        val wsDismissButton = findViewById<Button>(R.id.main_banner_websocket_dontaskagain)
-        val wsRemindButton = findViewById<Button>(R.id.main_banner_websocket_remind_later)
-        val wsEnableButton = findViewById<Button>(R.id.main_banner_websocket_enable)
-        wsText.movementMethod = LinkMovementMethod.getInstance() // Make links clickable
-        wsDismissButton.setOnClickListener {
-            wsBanner.visibility = View.GONE
-            repository.setWebSocketRemindTime(Repository.WEBSOCKET_REMIND_TIME_NEVER)
-        }
-        wsRemindButton.setOnClickListener {
-            wsBanner.visibility = View.GONE
-            repository.setWebSocketRemindTime(System.currentTimeMillis() + ONE_DAY_MILLIS)
-        }
-        wsEnableButton.setOnClickListener {
-            repository.setConnectionProtocol(Repository.CONNECTION_PROTOCOL_WS)
-            SubscriberServiceManager(this).restart()
-            wsBanner.visibility = View.GONE
-
-            // Maybe show WebSocketReconnectBanner
-            viewModel.list().observe(this) {
-                it?.let { subscriptions ->
-                    showHideWebSocketReconnectBanner(subscriptions)
-                }
-            }
-        }
-
-        // WebSocket Reconnect banner
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            val wsReconnectBanner = findViewById<View>(R.id.main_banner_websocket_reconnect)
-            val wsReconnectText = findViewById<TextView>(R.id.main_banner_websocket_reconnect_text)
-            val wsReconnectDismissButton = findViewById<Button>(R.id.main_banner_websocket_reconnect_dontaskagain)
-            val wsReconnectRemindButton = findViewById<Button>(R.id.main_banner_websocket_reconnect_remind_later)
-            val wsReconnectEnableButton = findViewById<Button>(R.id.main_banner_websocket_reconnect_enable)
-            wsReconnectText.movementMethod = LinkMovementMethod.getInstance() // Make links clickable
-            wsReconnectDismissButton.setOnClickListener {
-                wsReconnectBanner.visibility = View.GONE
-                repository.setWebSocketReconnectRemindTime(Repository.WEBSOCKET_RECONNECT_REMIND_TIME_NEVER)
-            }
-            wsReconnectRemindButton.setOnClickListener {
-                wsReconnectBanner.visibility = View.GONE
-                repository.setWebSocketReconnectRemindTime(System.currentTimeMillis() + ONE_DAY_MILLIS)
-            }
-            wsReconnectEnableButton.setOnClickListener {
-                startActivity(Intent(ACTION_REQUEST_SCHEDULE_EXACT_ALARM))
-            }
-        }
-
         // Create notification channels right away, so we can configure them immediately after installing the app
         dispatcher?.init()
 
@@ -244,6 +201,332 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
 
         // Permissions
         maybeRequestNotificationPermission()
+    }
+
+    private fun initializeAlertsPage(pageView: View) {
+        alertsPageView = pageView
+        if (alertsPageInitialized) {
+            return
+        }
+        alertsPageInitialized = true
+
+        fab = pageView.findViewById(R.id.fab)
+        fab.hide()
+        fab.isEnabled = false
+        fab.isClickable = false
+        fab.visibility = View.GONE
+
+        mainListContainer = pageView.findViewById(R.id.main_subscriptions_list_container)
+        mainListContainer.setOnRefreshListener { refreshAllSubscriptions() }
+        mainListContainer.setColorSchemeResources(Colors.refreshProgressIndicator)
+
+        val noEntries: View = pageView.findViewById(R.id.main_no_subscriptions)
+        val onSubscriptionClick = { s: Subscription -> onSubscriptionItemClick(s) }
+        val onSubscriptionLongClick = { s: Subscription -> onSubscriptionItemLongClick(s) }
+
+        mainList = pageView.findViewById(R.id.main_subscriptions_list)
+        mainList.layoutManager = LinearLayoutManager(this)
+        adapter = MainAdapter(repository, onSubscriptionClick, onSubscriptionLongClick)
+        mainList.adapter = adapter
+
+        viewModel.list().observe(this) { subscriptions ->
+            subscriptions?.let {
+                adapter.submitList(it as MutableList<Subscription>)
+                if (it.isEmpty()) {
+                    mainListContainer.visibility = View.GONE
+                    noEntries.visibility = View.VISIBLE
+                } else {
+                    mainListContainer.visibility = View.VISIBLE
+                    noEntries.visibility = View.GONE
+                }
+
+                it.forEach { s ->
+                    Log.addScrubTerm(shortUrl(s.baseUrl), Log.TermType.Domain)
+                    Log.addScrubTerm(s.topic)
+                }
+
+                showHideBatteryBanner(it)
+                showHideWebSocketBanner(it)
+                showHideWebSocketReconnectBanner(it)
+            }
+        }
+
+        val batteryBanner = pageView.findViewById<View>(R.id.main_banner_battery)
+        val dontAskAgainButton = pageView.findViewById<Button>(R.id.main_banner_battery_dontaskagain)
+        val askLaterButton = pageView.findViewById<Button>(R.id.main_banner_battery_ask_later)
+        val fixNowButton = pageView.findViewById<Button>(R.id.main_banner_battery_fix_now)
+        dontAskAgainButton.setOnClickListener {
+            batteryBanner.visibility = View.GONE
+            repository.setBatteryOptimizationsRemindTime(Repository.BATTERY_OPTIMIZATIONS_REMIND_TIME_NEVER)
+        }
+        askLaterButton.setOnClickListener {
+            batteryBanner.visibility = View.GONE
+            repository.setBatteryOptimizationsRemindTime(System.currentTimeMillis() + ONE_DAY_MILLIS)
+        }
+        fixNowButton.setOnClickListener {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                val intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+                startActivity(intent)
+            }
+        }
+
+        val wsBanner = pageView.findViewById<View>(R.id.main_banner_websocket)
+        val wsText = pageView.findViewById<TextView>(R.id.main_banner_websocket_text)
+        val wsDismissButton = pageView.findViewById<Button>(R.id.main_banner_websocket_dontaskagain)
+        val wsRemindButton = pageView.findViewById<Button>(R.id.main_banner_websocket_remind_later)
+        val wsEnableButton = pageView.findViewById<Button>(R.id.main_banner_websocket_enable)
+        wsText.movementMethod = LinkMovementMethod.getInstance()
+        wsDismissButton.setOnClickListener {
+            wsBanner.visibility = View.GONE
+            repository.setWebSocketRemindTime(Repository.WEBSOCKET_REMIND_TIME_NEVER)
+        }
+        wsRemindButton.setOnClickListener {
+            wsBanner.visibility = View.GONE
+            repository.setWebSocketRemindTime(System.currentTimeMillis() + ONE_DAY_MILLIS)
+        }
+        wsEnableButton.setOnClickListener {
+            repository.setConnectionProtocol(Repository.CONNECTION_PROTOCOL_WS)
+            SubscriberServiceManager(this).restart()
+            wsBanner.visibility = View.GONE
+
+            viewModel.list().observe(this) {
+                it?.let { subscriptions ->
+                    showHideWebSocketReconnectBanner(subscriptions)
+                }
+            }
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val wsReconnectBanner = pageView.findViewById<View>(R.id.main_banner_websocket_reconnect)
+            val wsReconnectText = pageView.findViewById<TextView>(R.id.main_banner_websocket_reconnect_text)
+            val wsReconnectDismissButton = pageView.findViewById<Button>(R.id.main_banner_websocket_reconnect_dontaskagain)
+            val wsReconnectRemindButton = pageView.findViewById<Button>(R.id.main_banner_websocket_reconnect_remind_later)
+            val wsReconnectEnableButton = pageView.findViewById<Button>(R.id.main_banner_websocket_reconnect_enable)
+            wsReconnectText.movementMethod = LinkMovementMethod.getInstance()
+            wsReconnectDismissButton.setOnClickListener {
+                wsReconnectBanner.visibility = View.GONE
+                repository.setWebSocketReconnectRemindTime(Repository.WEBSOCKET_RECONNECT_REMIND_TIME_NEVER)
+            }
+            wsReconnectRemindButton.setOnClickListener {
+                wsReconnectBanner.visibility = View.GONE
+                repository.setWebSocketReconnectRemindTime(System.currentTimeMillis() + ONE_DAY_MILLIS)
+            }
+            wsReconnectEnableButton.setOnClickListener {
+                startActivity(Intent(ACTION_REQUEST_SCHEDULE_EXACT_ALARM))
+            }
+        }
+    }
+
+    private fun initializeHistoryPage(pageView: View) {
+        if (historyInitialized) {
+            return
+        }
+        historyInitialized = true
+
+        historySwipeRefresh = pageView.findViewById(R.id.history_refresh_layout)
+        historySwipeRefresh?.setColorSchemeResources(Colors.refreshProgressIndicator)
+        historyLoadingView = pageView.findViewById(R.id.history_loading)
+        historyStatusText = pageView.findViewById(R.id.history_status_text)
+
+        val historyList = pageView.findViewById<RecyclerView>(R.id.history_list)
+        historyAdapter = QuakeHistoryAdapter()
+        historyList.layoutManager = LinearLayoutManager(this)
+        historyList.adapter = historyAdapter
+
+        historySwipeRefresh?.setOnRefreshListener { loadQuakeHistory(forceRefresh = true) }
+    }
+
+    private fun maybeLoadHistory(forceRefresh: Boolean = false) {
+        if (!historyInitialized) {
+            return
+        }
+        if (isLoadingHistory) {
+            return
+        }
+        if (!forceRefresh && historyAdapter?.currentList?.isNotEmpty() == true) {
+            return
+        }
+        loadQuakeHistory(forceRefresh)
+    }
+
+    private fun loadQuakeHistory(forceRefresh: Boolean = false) {
+        if (!historyInitialized) {
+            return
+        }
+        if (isLoadingHistory) {
+            return
+        }
+        if (!forceRefresh && historyAdapter?.currentList?.isNotEmpty() == true) {
+            return
+        }
+
+        isLoadingHistory = true
+        historyStatusText?.visibility = View.GONE
+        if (historySwipeRefresh?.isRefreshing != true) {
+            historyLoadingView?.visibility = View.VISIBLE
+        }
+
+        lifecycleScope.launch(Dispatchers.IO) {
+            try {
+                val request = Request.Builder()
+                    .url(getString(R.string.quake_history_url))
+                    .header("Accept", "application/json")
+                    .build()
+                val response = historyClient.newCall(request).execute()
+                response.use {
+                    if (!it.isSuccessful) {
+                        throw Exception("HTTP ${it.code}")
+                    }
+                    val body = it.body?.string()?.trim().orEmpty()
+                    val reports = parseEarthquakeReports(body)
+                    withContext(Dispatchers.Main) {
+                        historyAdapter?.submitList(reports)
+                        historyLoadingView?.visibility = View.GONE
+                        historySwipeRefresh?.isRefreshing = false
+                        if (reports.isEmpty()) {
+                            historyStatusText?.text = getString(R.string.quake_history_empty)
+                            historyStatusText?.visibility = View.VISIBLE
+                        } else {
+                            historyStatusText?.visibility = View.GONE
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to load quake history: ${e.message}", e)
+                withContext(Dispatchers.Main) {
+                    historyLoadingView?.visibility = View.GONE
+                    historySwipeRefresh?.isRefreshing = false
+                    val message = e.localizedMessage ?: e.javaClass.simpleName
+                    val shouldShowStatus = historyAdapter?.currentList?.isEmpty() != false
+                    if (shouldShowStatus) {
+                        historyStatusText?.text = getString(R.string.quake_history_error, message)
+                        historyStatusText?.visibility = View.VISIBLE
+                    }
+                }
+            } finally {
+                isLoadingHistory = false
+            }
+        }
+    }
+
+    private fun parseEarthquakeReports(body: String): List<EarthquakeReport> {
+        if (body.isBlank()) {
+            return emptyList()
+        }
+        val trimmed = body.trim()
+        val array = when {
+            trimmed.startsWith("[") -> JSONArray(trimmed)
+            trimmed.startsWith("{") -> {
+                val root = JSONObject(trimmed)
+                root.optJSONArray("data")
+                    ?: root.optJSONArray("laporan")
+                    ?: root.optJSONArray("results")
+                    ?: JSONArray().apply { put(root) }
+            }
+            else -> return emptyList()
+        }
+        val reports = mutableListOf<EarthquakeReport>()
+        for (i in 0 until array.length()) {
+            val obj = array.optJSONObject(i) ?: continue
+            reports.add(parseEarthquakeReport(obj))
+        }
+        return reports
+    }
+
+    private fun parseEarthquakeReport(obj: JSONObject): EarthquakeReport {
+        val id = obj.optString("id").ifBlank { obj.optString("ID") }
+        val time = listOf("waktu", "waktu_gempa", "datetime", "tanggal", "time", "jam")
+            .map { obj.optString(it) }
+            .firstOrNull { it.isNotBlank() } ?: ""
+        val magnitudeRaw = listOf("magnitudo", "magnitude", "mag", "sr")
+            .map { obj.optString(it) }
+            .firstOrNull { it.isNotBlank() } ?: ""
+        val depthRaw = listOf("kedalaman", "depth")
+            .map { obj.optString(it) }
+            .firstOrNull { it.isNotBlank() } ?: ""
+        val region = listOf("wilayah", "lokasi", "region", "area", "place", "daerah")
+            .map { obj.optString(it) }
+            .firstOrNull { it.isNotBlank() } ?: ""
+        val potential = listOf("potensi", "potential", "tsunami")
+            .map { obj.optString(it) }
+            .firstOrNull { it.isNotBlank() } ?: ""
+        val felt = listOf("dirasakan", "felt")
+            .map { obj.optString(it) }
+            .firstOrNull { it.isNotBlank() } ?: ""
+        val latitude = listOf("lintang", "latitude", "lat")
+            .map { obj.optString(it) }
+            .firstOrNull { it.isNotBlank() } ?: ""
+        val longitude = listOf("bujur", "longitude", "lon", "long")
+            .map { obj.optString(it) }
+            .firstOrNull { it.isNotBlank() } ?: ""
+
+        val knownKeys = setOf(
+            "id", "ID", "waktu", "waktu_gempa", "datetime", "tanggal", "time", "jam",
+            "magnitudo", "magnitude", "mag", "sr", "kedalaman", "depth",
+            "wilayah", "lokasi", "region", "area", "place", "daerah",
+            "potensi", "potential", "tsunami", "dirasakan", "felt",
+            "lintang", "latitude", "lat", "bujur", "longitude", "lon", "long"
+        )
+        val additional = mutableListOf<Pair<String, String>>()
+        val keys = obj.keys()
+        while (keys.hasNext()) {
+            val key = keys.next()
+            if (knownKeys.contains(key)) {
+                continue
+            }
+            val rawValue = obj.optString(key)
+            if (rawValue.isNullOrBlank()) {
+                continue
+            }
+            if (rawValue.equals("null", ignoreCase = true)) {
+                continue
+            }
+            val label = key.replaceFirstChar { character ->
+                if (character.isLowerCase()) {
+                    character.titlecase(Locale.getDefault())
+                } else {
+                    character.toString()
+                }
+            }
+            additional.add(label to rawValue)
+        }
+
+        return EarthquakeReport(
+            id = id,
+            time = time,
+            magnitude = formatMagnitude(magnitudeRaw),
+            depth = formatDepth(depthRaw),
+            region = region,
+            potential = potential,
+            felt = felt,
+            latitude = latitude,
+            longitude = longitude,
+            additionalDetails = additional
+        )
+    }
+
+    private fun formatMagnitude(value: String): String {
+        val trimmed = value.trim()
+        if (trimmed.isBlank()) {
+            return ""
+        }
+        return if (trimmed.startsWith("M", ignoreCase = true) || trimmed.contains("SR", ignoreCase = true)) {
+            trimmed
+        } else {
+            "M $trimmed"
+        }
+    }
+
+    private fun formatDepth(value: String): String {
+        val trimmed = value.trim()
+        if (trimmed.isBlank()) {
+            return ""
+        }
+        return if (trimmed.contains("km", ignoreCase = true)) {
+            trimmed
+        } else {
+            "$trimmed km"
+        }
     }
 
     private fun maybeRequestNotificationPermission() {
@@ -266,7 +549,8 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
         val batteryRemindTimeReached = repository.getBatteryOptimizationsRemindTime() < System.currentTimeMillis()
         val ignoringOptimizations = isIgnoringBatteryOptimizations(this@MainActivity)
         val showBanner = hasInstantSubscriptions && batteryRemindTimeReached && !ignoringOptimizations
-        val batteryBanner = findViewById<View>(R.id.main_banner_battery)
+        val view = alertsPageView ?: return
+        val batteryBanner = view.findViewById<View>(R.id.main_banner_battery)
         batteryBanner.visibility = if (showBanner) View.VISIBLE else View.GONE
         Log.d(TAG, "Battery: ignoring optimizations = $ignoringOptimizations (we want this to be true); instant subscriptions = $hasInstantSubscriptions; remind time reached = $batteryRemindTimeReached; banner = $showBanner")
     }
@@ -276,12 +560,14 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
         val usingWebSockets = repository.getConnectionProtocol() == Repository.CONNECTION_PROTOCOL_WS
         val wsRemindTimeReached = repository.getWebSocketRemindTime() < System.currentTimeMillis()
         val showBanner = hasSelfHostedSubscriptions && wsRemindTimeReached && !usingWebSockets
-        val wsBanner = findViewById<View>(R.id.main_banner_websocket)
+        val view = alertsPageView ?: return
+        val wsBanner = view.findViewById<View>(R.id.main_banner_websocket)
         wsBanner.visibility = if (showBanner) View.VISIBLE else View.GONE
     }
 
     private fun showHideWebSocketReconnectBanner(subscriptions: List<Subscription>) {
-        val wsReconnectBanner = findViewById<View>(R.id.main_banner_websocket_reconnect)
+        val view = alertsPageView ?: return
+        val wsReconnectBanner = view.findViewById<View>(R.id.main_banner_websocket_reconnect)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val hasSelfHostedSubscriptions = subscriptions.count { it.baseUrl != appBaseUrl } > 0
             val usingWebSockets = repository.getConnectionProtocol() == Repository.CONNECTION_PROTOCOL_WS

--- a/app/src/main/java/io/heckel/ntfy/ui/MainPagerAdapter.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/MainPagerAdapter.kt
@@ -1,0 +1,28 @@
+package io.heckel.ntfy.ui
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+
+class MainPagerAdapter(
+    private val layoutInflater: LayoutInflater,
+    private val layouts: List<Int>,
+    private val onPageBound: (position: Int, view: View) -> Unit
+) : RecyclerView.Adapter<MainPagerAdapter.PageViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PageViewHolder {
+        val view = layoutInflater.inflate(viewType, parent, false)
+        return PageViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: PageViewHolder, position: Int) {
+        onPageBound(position, holder.itemView)
+    }
+
+    override fun getItemCount(): Int = layouts.size
+
+    override fun getItemViewType(position: Int): Int = layouts[position]
+
+    class PageViewHolder(view: View) : RecyclerView.ViewHolder(view)
+}

--- a/app/src/main/java/io/heckel/ntfy/ui/history/EarthquakeReport.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/history/EarthquakeReport.kt
@@ -1,0 +1,22 @@
+package io.heckel.ntfy.ui.history
+
+data class EarthquakeReport(
+    val id: String = "",
+    val time: String = "",
+    val magnitude: String = "",
+    val depth: String = "",
+    val region: String = "",
+    val potential: String = "",
+    val felt: String = "",
+    val latitude: String = "",
+    val longitude: String = "",
+    val additionalDetails: List<Pair<String, String>> = emptyList()
+) {
+    val hasCoordinates: Boolean
+        get() = latitude.isNotBlank() || longitude.isNotBlank()
+
+    val coordinatesLabel: String
+        get() = listOf(latitude, longitude)
+            .filter { it.isNotBlank() }
+            .joinToString(separator = " • ")
+}

--- a/app/src/main/java/io/heckel/ntfy/ui/history/QuakeHistoryAdapter.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/history/QuakeHistoryAdapter.kt
@@ -1,0 +1,90 @@
+package io.heckel.ntfy.ui.history
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import io.heckel.ntfy.R
+
+class QuakeHistoryAdapter : ListAdapter<EarthquakeReport, QuakeHistoryAdapter.ViewHolder>(DIFF) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_quake_history, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val idView: TextView = itemView.findViewById(R.id.history_item_id)
+        private val regionView: TextView = itemView.findViewById(R.id.history_item_region)
+        private val timeView: TextView = itemView.findViewById(R.id.history_item_time)
+        private val magnitudeView: TextView = itemView.findViewById(R.id.history_item_magnitude)
+        private val depthView: TextView = itemView.findViewById(R.id.history_item_depth)
+        private val potentialView: TextView = itemView.findViewById(R.id.history_item_potential)
+        private val feltView: TextView = itemView.findViewById(R.id.history_item_felt)
+        private val coordinatesView: TextView = itemView.findViewById(R.id.history_item_coordinates)
+        private val additionalView: TextView = itemView.findViewById(R.id.history_item_additional)
+
+        fun bind(report: EarthquakeReport) {
+            idView.text = report.id
+            idView.isVisible = report.id.isNotBlank()
+
+            val fallbackTitle = itemView.context.getString(R.string.nav_history_title)
+            regionView.text = report.region.ifBlank { fallbackTitle }
+
+            timeView.text = report.time
+            timeView.isVisible = report.time.isNotBlank()
+
+            magnitudeView.text = report.magnitude
+            magnitudeView.isVisible = report.magnitude.isNotBlank()
+
+            if (report.depth.isNotBlank()) {
+                depthView.text = report.depth
+                depthView.visibility = View.VISIBLE
+            } else {
+                depthView.visibility = View.GONE
+            }
+
+            potentialView.text = report.potential
+            potentialView.isVisible = report.potential.isNotBlank()
+
+            feltView.text = report.felt
+            feltView.isVisible = report.felt.isNotBlank()
+
+            coordinatesView.text = report.coordinatesLabel
+            coordinatesView.isVisible = report.hasCoordinates
+
+            if (report.additionalDetails.isNotEmpty()) {
+                val formatted = report.additionalDetails.joinToString(separator = "\n") { (key, value) ->
+                    "$key: $value"
+                }
+                additionalView.text = formatted
+                additionalView.visibility = View.VISIBLE
+            } else {
+                additionalView.visibility = View.GONE
+            }
+        }
+    }
+
+    companion object {
+        private val DIFF = object : DiffUtil.ItemCallback<EarthquakeReport>() {
+            override fun areItemsTheSame(oldItem: EarthquakeReport, newItem: EarthquakeReport): Boolean {
+                return if (oldItem.id.isNotBlank() && newItem.id.isNotBlank()) {
+                    oldItem.id == newItem.id
+                } else {
+                    oldItem === newItem
+                }
+            }
+
+            override fun areContentsTheSame(oldItem: EarthquakeReport, newItem: EarthquakeReport): Boolean =
+                oldItem == newItem
+        }
+    }
+}

--- a/app/src/main/res/color/main_nav_item_color.xml
+++ b/app/src/main/res/color/main_nav_item_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true" android:color="?attr/colorPrimary" />
+    <item android:color="?attr/colorOnSurfaceVariant" />
+</selector>

--- a/app/src/main/res/drawable/bg_quake_id_chip.xml
+++ b/app/src/main/res/drawable/bg_quake_id_chip.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="50dp" />
+    <solid android:color="?attr/colorSecondaryContainer" />
+</shape>

--- a/app/src/main/res/drawable/bg_quake_info_surface.xml
+++ b/app/src/main/res/drawable/bg_quake_info_surface.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="18dp" />
+    <solid android:color="?attr/colorSecondaryContainer" />
+</shape>

--- a/app/src/main/res/drawable/bg_quake_metric_chip.xml
+++ b/app/src/main/res/drawable/bg_quake_metric_chip.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="20dp" />
+    <solid android:color="?attr/colorTertiaryContainer" />
+</shape>

--- a/app/src/main/res/drawable/ic_nav_alerts.xml
+++ b/app/src/main/res/drawable/ic_nav_alerts.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M1,21h22L12,3 1,21z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11,9h2l-0.3,6h-1.4z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11,17a1,1 0 1,0 2,0a1,1 0 1,0 -2,0" />
+</vector>

--- a/app/src/main/res/drawable/ic_nav_history.xml
+++ b/app/src/main/res/drawable/ic_nav_history.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2a10,10 0 1,0 0,20a10,10 0 0,0 0,-20z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12.5,7h-1.5v6l5.2,3.1l0.75,-1.23l-4.45,-2.67z" />
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,290 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                                   xmlns:app="http://schemas.android.com/apk/res-auto"
-                                                   xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-                                                   android:layout_height="match_parent">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <com.google.android.material.card.MaterialCardView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:shapeAppearance="?shapeAppearanceLargeComponent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            android:id="@+id/main_banner_battery"
-            android:visibility="visible"
-    >
-        <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/main_banner_battery_constraint" android:elevation="5dp">
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/main_view_pager"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@id/main_bottom_navigation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-            <ImageView
-                    android:layout_width="28dp"
-                    android:layout_height="28dp" app:srcCompat="@drawable/ic_battery_alert_red_24dp"
-                    android:id="@+id/main_banner_battery_image"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@+id/main_banner_battery_text"
-                    app:layout_constraintEnd_toStartOf="@id/main_banner_battery_text"
-                    app:layout_constraintBottom_toBottomOf="@+id/main_banner_battery_text"
-                    android:layout_marginStart="15dp"/>
-            <TextView
-                    android:id="@+id/main_banner_battery_text"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:text="@string/main_banner_battery_text"
-                    android:textAppearance="@style/TextAppearance.AppCompat.Small"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    android:layout_marginEnd="15dp" android:layout_marginTop="15dp"
-                    app:layout_constraintStart_toEndOf="@+id/main_banner_battery_image"
-                    android:layout_marginStart="10dp"/>
-
-            <androidx.constraintlayout.helper.widget.Flow
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:constraint_referenced_ids="main_banner_battery_ask_later,main_banner_battery_dontaskagain,main_banner_battery_fix_now"
-                    app:layout_constraintTop_toBottomOf="@id/main_banner_battery_text"
-                    app:flow_horizontalAlign="end"
-                    app:flow_wrapMode="chain"
-                    app:flow_horizontalStyle="packed"
-                    android:layout_marginEnd="15dp"
-                    android:id="@+id/main_banner_battery_flow"
-                    app:layout_constraintStart_toStartOf="parent"
-                    android:layout_marginStart="15dp"
-                    app:flow_horizontalBias="1"
-                    app:flow_verticalGap="0dp" app:flow_horizontalGap="0dp"/>
-
-            <com.google.android.material.button.MaterialButton
-                    android:id="@+id/main_banner_battery_ask_later"
-                    style="@style/Widget.MaterialComponents.Button.TextButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/main_banner_battery_button_remind_later"
-                    tools:layout_editor_absoluteX="15dp" tools:layout_editor_absoluteY="67dp"/>
-
-            <com.google.android.material.button.MaterialButton
-                    android:id="@+id/main_banner_battery_dontaskagain"
-                    style="@style/Widget.MaterialComponents.Button.TextButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/main_banner_battery_button_dismiss"
-                    tools:layout_editor_absoluteX="142dp" tools:layout_editor_absoluteY="71dp"/>
-            <com.google.android.material.button.MaterialButton
-                    android:id="@+id/main_banner_battery_fix_now"
-                    style="@style/Widget.MaterialComponents.Button.TextButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/main_banner_battery_button_fix_now"
-                    tools:layout_editor_absoluteX="269dp" tools:layout_editor_absoluteY="67dp"/>
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </com.google.android.material.card.MaterialCardView>
-
-    <com.google.android.material.card.MaterialCardView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:shapeAppearance="?shapeAppearanceLargeComponent" app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" app:layout_constraintTop_toBottomOf="@+id/main_banner_battery"
-            android:id="@+id/main_banner_websocket" android:visibility="visible">
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/main_banner_websocket_constraint" android:elevation="5dp">
-
-            <ImageView
-                    android:layout_width="28dp"
-                    android:layout_height="28dp" app:srcCompat="@drawable/ic_announcement_orange_24dp"
-                    android:id="@+id/main_banner_websocket_image"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@+id/main_banner_websocket_text"
-                    app:layout_constraintEnd_toStartOf="@id/main_banner_websocket_text"
-                    app:layout_constraintBottom_toBottomOf="@+id/main_banner_websocket_text"
-                    android:layout_marginStart="15dp"/>
-            <TextView
-                    android:id="@+id/main_banner_websocket_text"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:text="@string/main_banner_websocket_text"
-                    android:textAppearance="@style/TextAppearance.AppCompat.Small"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    android:layout_marginEnd="15dp" android:layout_marginTop="15dp"
-                    app:layout_constraintStart_toEndOf="@+id/main_banner_websocket_image"
-                    android:layout_marginStart="10dp"
-            />
-
-            <androidx.constraintlayout.helper.widget.Flow
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:constraint_referenced_ids="main_banner_websocket_remind_later,main_banner_websocket_dontaskagain,main_banner_websocket_enable" app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_text" app:flow_horizontalAlign="end" app:flow_wrapMode="chain" app:flow_horizontalStyle="packed" android:layout_marginEnd="15dp" android:id="@+id/flow" app:layout_constraintStart_toStartOf="parent" android:layout_marginStart="15dp" app:flow_horizontalBias="1"
-                    app:flow_verticalGap="0dp" app:flow_horizontalGap="0dp"/>
-
-            <com.google.android.material.button.MaterialButton
-                    android:id="@+id/main_banner_websocket_remind_later"
-                    style="@style/Widget.MaterialComponents.Button.TextButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/main_banner_websocket_button_remind_later"
-                    tools:layout_editor_absoluteX="86dp" tools:layout_editor_absoluteY="83dp"/>
-
-            <com.google.android.material.button.MaterialButton
-                    android:id="@+id/main_banner_websocket_dontaskagain"
-                    style="@style/Widget.MaterialComponents.Button.TextButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/main_banner_websocket_button_dismiss"
-                    tools:layout_editor_absoluteX="260dp" tools:layout_editor_absoluteY="83dp"/>
-
-            <com.google.android.material.button.MaterialButton
-                    android:id="@+id/main_banner_websocket_enable"
-                    style="@style/Widget.MaterialComponents.Button.TextButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/main_banner_websocket_button_enable_now"
-                    tools:layout_editor_absoluteX="253dp" tools:layout_editor_absoluteY="131dp"/>
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </com.google.android.material.card.MaterialCardView>
-
-    <com.google.android.material.card.MaterialCardView
-        android:layout_width="match_parent"
+    <com.google.android.material.navigation.NavigationBarView
+        android:id="@+id/main_bottom_navigation"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:shapeAppearance="?shapeAppearanceLargeComponent" app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" app:layout_constraintTop_toBottomOf="@+id/main_banner_websocket"
-        android:id="@+id/main_banner_websocket_reconnect" android:visibility="visible">
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:id="@+id/main_banner_websocket_reconnect_constraint" android:elevation="5dp">
-
-            <ImageView
-                android:layout_width="28dp"
-                android:layout_height="28dp" app:srcCompat="@drawable/ic_announcement_orange_24dp"
-                android:id="@+id/main_banner_websocket_reconnect_image"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/main_banner_websocket_reconnect_text"
-                app:layout_constraintEnd_toStartOf="@id/main_banner_websocket_reconnect_text"
-                app:layout_constraintBottom_toBottomOf="@+id/main_banner_websocket_reconnect_text"
-                android:layout_marginStart="15dp"/>
-            <TextView
-                android:id="@+id/main_banner_websocket_reconnect_text"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="@string/main_banner_websocket_reconnect_text"
-                android:textAppearance="@style/TextAppearance.AppCompat.Small"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                android:layout_marginEnd="15dp" android:layout_marginTop="15dp"
-                app:layout_constraintStart_toEndOf="@+id/main_banner_websocket_reconnect_image"
-                android:layout_marginStart="10dp"
-                />
-
-            <androidx.constraintlayout.helper.widget.Flow
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:constraint_referenced_ids="main_banner_websocket_reconnect_remind_later,main_banner_websocket_reconnect_dontaskagain,main_banner_websocket_reconnect_enable" app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_reconnect_text" app:flow_horizontalAlign="end" app:flow_wrapMode="chain" app:flow_horizontalStyle="packed" android:layout_marginEnd="15dp" android:id="@+id/flow_reconnect" app:layout_constraintStart_toStartOf="parent" android:layout_marginStart="15dp" app:flow_horizontalBias="1"
-                app:flow_verticalGap="0dp" app:flow_horizontalGap="0dp"/>
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/main_banner_websocket_reconnect_remind_later"
-                style="@style/Widget.MaterialComponents.Button.TextButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/main_banner_websocket_reconnect_button_remind_later"
-                tools:layout_editor_absoluteX="86dp" tools:layout_editor_absoluteY="83dp"/>
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/main_banner_websocket_reconnect_dontaskagain"
-                style="@style/Widget.MaterialComponents.Button.TextButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/main_banner_websocket_reconnect_button_dismiss"
-                tools:layout_editor_absoluteX="260dp" tools:layout_editor_absoluteY="83dp"/>
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/main_banner_websocket_reconnect_enable"
-                style="@style/Widget.MaterialComponents.Button.TextButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/main_banner_websocket_reconnect_button_enable_now"
-                tools:layout_editor_absoluteX="253dp" tools:layout_editor_absoluteY="131dp"/>
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </com.google.android.material.card.MaterialCardView>
-
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-            android:id="@+id/main_subscriptions_list_container"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:visibility="visible"
-            app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_reconnect">
-        <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/main_subscriptions_list"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:clickable="true"
-                android:focusable="true"
-                android:paddingTop="5dp"
-                android:paddingBottom="5dp"
-                android:clipToPadding="false"
-                android:background="?android:attr/selectableItemBackground"
-                app:layoutManager="LinearLayoutManager"/>
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
-
-    <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toTopOf="@+id/fab" app:layout_constraintStart_toStartOf="parent"
-            android:id="@+id/main_no_subscriptions" android:visibility="gone">
-        <ImageView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" app:srcCompat="@drawable/ic_sms_gray_48dp"
-                android:id="@+id/main_no_subscriptions_image"/>
-        <TextView
-                android:id="@+id/main_no_subscriptions_text"
-                android:text="@string/main_no_subscriptions_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-                android:padding="10dp" android:gravity="center_horizontal"
-                android:paddingStart="50dp" android:paddingEnd="50dp"/>
-        <TextView
-                android:text="@string/main_how_to_intro"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/main_how_to_intro"
-                android:layout_marginTop="20dp"
-                android:layout_marginStart="50dp"
-                android:layout_marginEnd="50dp"/>
-        <TextView
-                android:text="@string/main_how_to_link"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/main_how_to_link"
-                android:layout_marginTop="7dp"
-                android:layout_marginStart="50dp"
-                android:layout_marginEnd="50dp"
-                android:linksClickable="true"
-                android:autoLink="web"/>
-    </LinearLayout>
-
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/fab"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="24dp"
-            android:contentDescription="@string/main_add_button_description"
-            android:src="@drawable/ic_add_black_24dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            style="@style/FloatingActionButton"
-    />
+        android:background="?attr/colorSurface"
+        android:paddingTop="6dp"
+        android:paddingBottom="6dp"
+        app:itemIconSize="24dp"
+        app:itemIconTint="@color/main_nav_item_color"
+        app:itemTextColor="@color/main_nav_item_color"
+        app:labelVisibilityMode="labeled"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:menu="@menu/menu_main_navigation" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_quake_history.xml
+++ b/app/src/main/res/layout/item_quake_history.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="12dp"
+    app:cardBackgroundColor="?attr/colorSurface"
+    app:cardCornerRadius="24dp"
+    app:cardElevation="2dp"
+    app:strokeColor="?attr/colorOutline"
+    app:strokeWidth="0.5dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="20dp">
+
+        <TextView
+            android:id="@+id/history_item_id"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_quake_id_chip"
+            android:paddingStart="12dp"
+            android:paddingTop="4dp"
+            android:paddingEnd="12dp"
+            android:paddingBottom="4dp"
+            android:textAllCaps="true"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.LabelSmall"
+            android:textColor="?attr/colorOnSecondaryContainer"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/history_item_region"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.TitleMedium"
+            android:textColor="?attr/colorOnBackground"
+            android:textStyle="bold"
+            tools:text="Wilayah 5 km Barat Daya Jakarta" />
+
+        <TextView
+            android:id="@+id/history_item_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.BodyMedium"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            tools:text="21 Sep 2024 15:32 WIB" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:gravity="start"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/history_item_magnitude"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/bg_quake_metric_chip"
+                android:paddingStart="14dp"
+                android:paddingTop="6dp"
+                android:paddingEnd="14dp"
+                android:paddingBottom="6dp"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.BodyLarge"
+                android:textColor="?attr/colorOnTertiaryContainer"
+                android:textStyle="bold"
+                tools:text="M 5.4" />
+
+            <TextView
+                android:id="@+id/history_item_depth"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:background="@drawable/bg_quake_metric_chip"
+                android:paddingStart="14dp"
+                android:paddingTop="6dp"
+                android:paddingEnd="14dp"
+                android:paddingBottom="6dp"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.BodyLarge"
+                android:textColor="?attr/colorOnTertiaryContainer"
+                tools:text="10 km" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/history_item_potential"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/bg_quake_info_surface"
+            android:padding="12dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.BodyMedium"
+            android:textColor="?attr/colorOnSecondaryContainer"
+            android:visibility="gone"
+            tools:text="Tidak berpotensi tsunami" />
+
+        <TextView
+            android:id="@+id/history_item_felt"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.BodyMedium"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:visibility="gone"
+            tools:text="Dirasakan hingga IV MMI di Jakarta" />
+
+        <TextView
+            android:id="@+id/history_item_coordinates"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.LabelLarge"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:visibility="gone"
+            tools:text="6.2° LS • 106.8° BT" />
+
+        <TextView
+            android:id="@+id/history_item_additional"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.BodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:visibility="gone"
+            tools:text="Shake ID: 20240921123
+Sumber: BMKG" />
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/main_page_quake_alerts.xml
+++ b/app/src/main/res/layout/main_page_quake_alerts.xml
@@ -1,0 +1,351 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="8dp">
+
+    <TextView
+        android:id="@+id/main_header_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="24dp"
+        android:text="@string/main_header_quake_alerts"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.HeadlineSmall"
+        android:textColor="?attr/colorOnBackground"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/main_banner_battery"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="20dp"
+        android:visibility="visible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/main_header_title"
+        app:shapeAppearance="?shapeAppearanceLargeComponent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/main_banner_battery_constraint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:elevation="5dp">
+
+            <ImageView
+                android:id="@+id/main_banner_battery_image"
+                android:layout_width="28dp"
+                android:layout_height="28dp"
+                android:layout_marginStart="15dp"
+                app:layout_constraintBottom_toBottomOf="@+id/main_banner_battery_text"
+                app:layout_constraintEnd_toStartOf="@id/main_banner_battery_text"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/main_banner_battery_text"
+                app:srcCompat="@drawable/ic_battery_alert_red_24dp" />
+
+            <TextView
+                android:id="@+id/main_banner_battery_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="15dp"
+                android:layout_marginEnd="15dp"
+                android:text="@string/main_banner_battery_text"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/main_banner_battery_image"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <androidx.constraintlayout.helper.widget.Flow
+                android:id="@+id/main_banner_battery_flow"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="15dp"
+                android:layout_marginEnd="15dp"
+                app:constraint_referenced_ids="main_banner_battery_ask_later,main_banner_battery_dontaskagain,main_banner_battery_fix_now"
+                app:flow_horizontalAlign="end"
+                app:flow_horizontalBias="1"
+                app:flow_horizontalGap="0dp"
+                app:flow_horizontalStyle="packed"
+                app:flow_verticalGap="0dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/main_banner_battery_text" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_battery_ask_later"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_battery_button_remind_later" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_battery_dontaskagain"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_battery_button_dismiss" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_battery_fix_now"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_battery_button_fix_now" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/main_banner_websocket"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="20dp"
+        android:visibility="visible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/main_banner_battery"
+        app:shapeAppearance="?shapeAppearanceLargeComponent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/main_banner_websocket_constraint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:elevation="5dp">
+
+            <ImageView
+                android:id="@+id/main_banner_websocket_image"
+                android:layout_width="28dp"
+                android:layout_height="28dp"
+                android:layout_marginStart="15dp"
+                app:layout_constraintBottom_toBottomOf="@+id/main_banner_websocket_text"
+                app:layout_constraintEnd_toStartOf="@id/main_banner_websocket_text"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/main_banner_websocket_text"
+                app:srcCompat="@drawable/ic_announcement_orange_24dp" />
+
+            <TextView
+                android:id="@+id/main_banner_websocket_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="15dp"
+                android:layout_marginEnd="15dp"
+                android:text="@string/main_banner_websocket_text"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/main_banner_websocket_image"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <androidx.constraintlayout.helper.widget.Flow
+                android:id="@+id/flow"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="15dp"
+                android:layout_marginEnd="15dp"
+                app:constraint_referenced_ids="main_banner_websocket_remind_later,main_banner_websocket_dontaskagain,main_banner_websocket_enable"
+                app:flow_horizontalAlign="end"
+                app:flow_horizontalBias="1"
+                app:flow_horizontalGap="0dp"
+                app:flow_horizontalStyle="packed"
+                app:flow_verticalGap="0dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_text" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_websocket_remind_later"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_websocket_button_remind_later" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_websocket_dontaskagain"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_websocket_button_dismiss" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_websocket_enable"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_websocket_button_enable_now" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/main_banner_websocket_reconnect"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="20dp"
+        android:visibility="visible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/main_banner_websocket"
+        app:shapeAppearance="?shapeAppearanceLargeComponent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/main_banner_websocket_reconnect_constraint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:elevation="5dp">
+
+            <ImageView
+                android:id="@+id/main_banner_websocket_reconnect_image"
+                android:layout_width="28dp"
+                android:layout_height="28dp"
+                android:layout_marginStart="15dp"
+                app:layout_constraintBottom_toBottomOf="@+id/main_banner_websocket_reconnect_text"
+                app:layout_constraintEnd_toStartOf="@id/main_banner_websocket_reconnect_text"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/main_banner_websocket_reconnect_text"
+                app:srcCompat="@drawable/ic_announcement_orange_24dp" />
+
+            <TextView
+                android:id="@+id/main_banner_websocket_reconnect_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="15dp"
+                android:layout_marginEnd="15dp"
+                android:text="@string/main_banner_websocket_reconnect_text"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/main_banner_websocket_reconnect_image"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <androidx.constraintlayout.helper.widget.Flow
+                android:id="@+id/flow_reconnect"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="15dp"
+                android:layout_marginEnd="15dp"
+                app:constraint_referenced_ids="main_banner_websocket_reconnect_remind_later,main_banner_websocket_reconnect_dontaskagain,main_banner_websocket_reconnect_enable"
+                app:flow_horizontalAlign="end"
+                app:flow_horizontalBias="1"
+                app:flow_horizontalGap="0dp"
+                app:flow_horizontalStyle="packed"
+                app:flow_verticalGap="0dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_reconnect_text" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_websocket_reconnect_remind_later"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_websocket_reconnect_button_remind_later" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_websocket_reconnect_dontaskagain"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_websocket_reconnect_button_dismiss" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_websocket_reconnect_enable"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_websocket_reconnect_button_enable_now" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/main_subscriptions_list_container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:visibility="visible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_reconnect">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/main_subscriptions_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?android:attr/selectableItemBackground"
+            android:clickable="true"
+            android:clipToPadding="false"
+            android:focusable="true"
+            android:paddingTop="5dp"
+            android:paddingBottom="5dp"
+            app:layoutManager="LinearLayoutManager" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <LinearLayout
+        android:id="@+id/main_no_subscriptions"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:paddingBottom="24dp"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@+id/fab"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/main_header_title">
+
+        <ImageView
+            android:id="@+id/main_no_subscriptions_image"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:srcCompat="@drawable/ic_sms_gray_48dp" />
+
+        <TextView
+            android:id="@+id/main_no_subscriptions_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:padding="10dp"
+            android:text="@string/main_no_subscriptions_text"
+            android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+        <TextView
+            android:id="@+id/main_how_to_intro"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/main_how_to_intro" />
+
+        <TextView
+            android:id="@+id/main_how_to_link"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="7dp"
+            android:autoLink="web"
+            android:linksClickable="true"
+            android:text="@string/main_how_to_link" />
+    </LinearLayout>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab"
+        style="@style/FloatingActionButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="24dp"
+        android:contentDescription="@string/main_add_button_description"
+        android:src="@drawable/ic_add_black_24dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/main_page_quake_history.xml
+++ b/app/src/main/res/layout/main_page_quake_history.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="16dp">
+
+    <TextView
+        android:id="@+id/history_header_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="24dp"
+        android:text="@string/history_header_title"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.HeadlineSmall"
+        android:textColor="?attr/colorOnBackground"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/history_header_subtitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="24dp"
+        android:text="@string/history_header_description"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.BodyMedium"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/history_header_title" />
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/history_refresh_layout"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/history_header_subtitle">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/history_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp"
+            tools:listitem="@layout/item_quake_history" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/history_loading"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/history_refresh_layout"
+        app:layout_constraintEnd_toEndOf="@id/history_refresh_layout"
+        app:layout_constraintStart_toStartOf="@id/history_refresh_layout"
+        app:layout_constraintTop_toTopOf="@id/history_refresh_layout" />
+
+    <TextView
+        android:id="@+id/history_status_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginEnd="32dp"
+        android:gravity="center"
+        android:text="@string/quake_history_empty"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.BodyMedium"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/history_refresh_layout"
+        app:layout_constraintEnd_toEndOf="@id/history_refresh_layout"
+        app:layout_constraintStart_toStartOf="@id/history_refresh_layout"
+        app:layout_constraintTop_toTopOf="@id/history_refresh_layout" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/menu_main_navigation.xml
+++ b/app/src/main/res/menu/menu_main_navigation.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/nav_alerts"
+        android:icon="@drawable/ic_nav_alerts"
+        android:title="@string/nav_alerts_title" />
+    <item
+        android:id="@+id/nav_history"
+        android:icon="@drawable/ic_nav_history"
+        android:title="@string/nav_history_title" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,13 @@
 
     <!-- Main activity: Action bar -->
     <string name="main_action_bar_title">Subscribed topics</string>
+    <string name="main_header_quake_alerts">Subscribed Topics to Quake Alerts</string>
+    <string name="nav_alerts_title">Quake Alerts</string>
+    <string name="nav_history_title">Quake History Reports</string>
+    <string name="history_header_title">Quake History Reports</string>
+    <string name="history_header_description">Stay informed with the latest earthquake activity captured by QuakeAlert.</string>
+    <string name="quake_history_empty">No quake history is available yet.</string>
+    <string name="quake_history_error">Could not load quake history.\n%1$s</string>
     <string name="main_menu_notifications_enabled">Notifications on</string>
     <string name="main_menu_notifications_disabled_forever">Notifications muted</string>
     <string name="main_menu_notifications_disabled_until">Notifications muted until %1$s</string>

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -6,6 +6,7 @@
     <!-- Main app constants -->
     <string name="app_name" translatable="false">QuakeAlert</string>
     <string name="app_base_url" translatable="false">https://quakealert.bananapixel.my.id/ntfy</string> <!-- If changed, you must also change google-services.json! -->
+    <string name="quake_history_url" translatable="false">https://quakealert.bananapixel.my.id/laporan</string>
 
     <!-- Main activity -->
     <string name="main_menu_report_bug_url" translatable="false">https://github.com/binwiederhier/ntfy/issues</string>


### PR DESCRIPTION
## Summary
- replace the main activity content with a Material navigation bar and view pager for the Quake Alerts and Quake History tabs
- refresh the alerts page layout with a descriptive header and margins while keeping existing subscription controls
- implement a quake history feed that downloads reports, renders Material cards, and handles swipe-to-refresh states

## Testing
- ./gradlew lint *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb35fbc60832d8a7f8003ee4ed0dc