### PR TITLE
Show quake intensity when magnitude is missing

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/ui/QuakeHistoryAdapter.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/QuakeHistoryAdapter.kt
@@ -58,20 +58,31 @@ class QuakeHistoryAdapter : RecyclerView.Adapter<QuakeHistoryAdapter.QuakeHistor
         fun bind(report: QuakeReport) {
             val context = itemView.context
 
-            val magnitudeText = formatMagnitudeText(report.magnitude)
+            val magnitudeRaw = report.magnitude
+            val hasMagnitude = !magnitudeRaw.isNullOrBlank()
+            val magnitudeText = formatMagnitudeText(magnitudeRaw)
             val intensityText = formatIntensityText(findIntensityValue(report))
-            magnitudeView.text = buildMagnitudeBadgeText(magnitudeText, intensityText)
-            magnitudeView.contentDescription = if (intensityText != null) {
-                context.getString(
-                    R.string.quake_history_magnitude_intensity_badge_content_description,
-                    magnitudeText,
-                    intensityText
-                )
-            } else {
-                context.getString(
-                    R.string.quake_history_magnitude_badge_content_description,
-                    magnitudeText
-                )
+            magnitudeView.text = buildMagnitudeBadgeText(magnitudeText, intensityText, hasMagnitude)
+            magnitudeView.contentDescription = when {
+                intensityText != null && hasMagnitude -> {
+                    context.getString(
+                        R.string.quake_history_magnitude_intensity_badge_content_description,
+                        magnitudeText,
+                        intensityText
+                    )
+                }
+                intensityText != null -> {
+                    context.getString(
+                        R.string.quake_history_intensity_badge_content_description,
+                        intensityText
+                    )
+                }
+                else -> {
+                    context.getString(
+                        R.string.quake_history_magnitude_badge_content_description,
+                        magnitudeText
+                    )
+                }
             }
             val magnitudeColor = ContextCompat.getColor(context, magnitudeColorRes(parseMagnitude(report.magnitude)))
             magnitudeView.background?.let { drawable ->
@@ -226,7 +237,14 @@ class QuakeHistoryAdapter : RecyclerView.Adapter<QuakeHistoryAdapter.QuakeHistor
             return ROMAN_INTENSITY_REGEX.containsMatchIn(text)
         }
 
-        private fun buildMagnitudeBadgeText(magnitude: String, intensity: String?): CharSequence {
+        private fun buildMagnitudeBadgeText(
+            magnitude: String,
+            intensity: String?,
+            hasMagnitude: Boolean
+        ): CharSequence {
+            if (!hasMagnitude && !intensity.isNullOrBlank()) {
+                return intensity
+            }
             if (intensity.isNullOrBlank()) {
                 return magnitude
             }

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -167,6 +167,8 @@
     <string name="quake_history_empty">Belum ada laporan riwayat gempa.</string>
     <string name="quake_history_magnitude_placeholder">--</string>
     <string name="quake_history_magnitude_badge_content_description">Magnitudo %1$s</string>
+    <string name="quake_history_magnitude_intensity_badge_content_description">Magnitudo %1$s, intensitas %2$s</string>
+    <string name="quake_history_intensity_badge_content_description">Intensitas %1$s</string>
     <string name="quake_history_chip_depth">Kedalaman • %1$s</string>
     <string name="quake_history_chip_coordinates">Koordinat • %1$s</string>
     <string name="quake_history_felt_format">Laporan dirasakan: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -169,6 +169,7 @@
     <string name="quake_history_magnitude_placeholder">--</string>
     <string name="quake_history_magnitude_badge_content_description">Magnitude %1$s</string>
     <string name="quake_history_magnitude_intensity_badge_content_description">Magnitude %1$s, intensity %2$s</string>
+    <string name="quake_history_intensity_badge_content_description">Intensity %1$s</string>
     <string name="quake_history_chip_depth">Depth • %1$s</string>
     <string name="quake_history_chip_coordinates">Coordinates • %1$s</string>
     <string name="quake_history_felt_format">Felt reports: %1$s</string>


### PR DESCRIPTION
## Summary
- display quake intensity in the badge when magnitude data is absent
- adjust content descriptions and add intensity-only string resources for accessibility

## Testing
- ./gradlew lint *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d01e29124c832d9af8d9de812e5759