### PR TITLE
Adjust quake intensity badge display and coloring

### DIFF
--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -178,6 +178,7 @@
     <string name="quake_history_label_event_id">ID Kejadian</string>
     <string name="quake_history_label_source">Sumber</string>
     <string name="quake_history_label_updated">Diperbarui</string>
+    <string name="quake_history_label_intensity">Intensitas</string>
     <string name="quake_history_unknown_location">Lokasi tidak diketahui</string>
     <string name="settings_general_default_base_url_default_summary">%1$s (bawaan)</string>
     <string name="settings_general_users_title">Kelola pengguna</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,6 +17,11 @@
     <color name="magnitude_low">#2E7D32</color>
     <color name="magnitude_moderate">#FB8C00</color>
     <color name="magnitude_high">#C62828</color>
+    <color name="intensity_weak">#2E7D32</color>
+    <color name="intensity_moderate">#F9A825</color>
+    <color name="intensity_strong">#FB8C00</color>
+    <color name="intensity_very_strong">#F4511E</color>
+    <color name="intensity_extreme">#B71C1C</color>
     <color name="highlight_chip_background">#E8F5E9</color>
     <color name="highlight_chip_text">#1B5E20</color>
     <color name="highlight_chip_stroke">#C8E6C9</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -179,6 +179,7 @@
     <string name="quake_history_label_event_id">Event ID</string>
     <string name="quake_history_label_source">Source</string>
     <string name="quake_history_label_updated">Updated</string>
+    <string name="quake_history_label_intensity">Intensity</string>
     <string name="quake_history_unknown_location">Unknown location</string>
     <string name="detail_item_cannot_open_not_found">Cannot open attachment: The file may have been deleted, or no installed app can open the file.</string>
     <string name="detail_item_cannot_open_url">Cannot open URL: %1$s</string>


### PR DESCRIPTION
## Summary
- show only the abbreviated intensity code on the quake history badge while keeping the full description for accessibility
- tint the badge using a green-to-red scale derived from the parsed intensity level and add supporting resources
- surface the intensity description inside the “More details” section when available

## Testing
- ./gradlew lint *(fails: Android SDK not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0219c84f0832d9463e43b4d4ad382