### PR TITLE
Ensure bottom navigation stays steady on tap

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
@@ -32,6 +32,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.work.*
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.google.android.material.navigation.NavigationBarView
 import io.heckel.ntfy.BuildConfig
 import io.heckel.ntfy.R
 import io.heckel.ntfy.app.Application
@@ -90,6 +91,8 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
 
         // Navigation bar
         bottomNavigation = findViewById(R.id.bottom_navigation)
+        bottomNavigation.isItemHorizontalTranslationEnabled = false
+        bottomNavigation.labelVisibilityMode = NavigationBarView.LABEL_VISIBILITY_LABELED
         bottomNavigation.setOnItemSelectedListener { item ->
             when (item.itemId) {
                 R.id.menu_alerts -> true

--- a/app/src/main/java/io/heckel/ntfy/ui/QuakeHistoryActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/QuakeHistoryActivity.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.google.android.material.navigation.NavigationBarView
 import io.heckel.ntfy.R
 import io.heckel.ntfy.msg.ApiService
 import kotlinx.coroutines.Dispatchers
@@ -44,6 +45,8 @@ class QuakeHistoryActivity : AppCompatActivity() {
         title = getString(R.string.quake_history_title)
 
         bottomNavigation = findViewById(R.id.bottom_navigation)
+        bottomNavigation.isItemHorizontalTranslationEnabled = false
+        bottomNavigation.labelVisibilityMode = NavigationBarView.LABEL_VISIBILITY_LABELED
         bottomNavigation.selectedItemId = R.id.menu_history
         bottomNavigation.setOnItemSelectedListener { item ->
             when (item.itemId) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -301,6 +301,7 @@
                 android:paddingStart="12dp"
                 android:paddingEnd="12dp"
                 style="@style/Widget.Quake.BottomNavigationView"
+                app:itemHorizontalTranslationEnabled="false"
                 app:menu="@menu/menu_bottom_navigation" />
 
     </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/activity_quake_history.xml
+++ b/app/src/main/res/layout/activity_quake_history.xml
@@ -78,6 +78,7 @@
             android:paddingStart="12dp"
             android:paddingEnd="12dp"
             style="@style/Widget.Quake.BottomNavigationView"
+            app:itemHorizontalTranslationEnabled="false"
             app:menu="@menu/menu_bottom_navigation" />
 
     </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary
- enforce non-shifting behavior for the bottom navigation on the main and history screens in code so the items remain stable when tapped
- force labeled mode on the navigation items to avoid selection animations that move the icons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0254fb924832d80c57db5022d0131