### PR TITLE
Format quake report durations with seconds

### DIFF
--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -174,6 +174,7 @@
     <string name="quake_history_felt_format">Laporan dirasakan: %1$s</string>
     <string name="quake_history_notes_format">Catatan: %1$s</string>
     <string name="quake_history_more_details">Detail lainnya</string>
+    <string name="quake_history_duration_value_format">%1$s detik</string>
     <string name="quake_history_label_shakemap">Shakemap</string>
     <string name="quake_history_label_event_id">ID Kejadian</string>
     <string name="quake_history_label_source">Sumber</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,6 +175,7 @@
     <string name="quake_history_felt_format">Felt reports: %1$s</string>
     <string name="quake_history_notes_format">Notes: %1$s</string>
     <string name="quake_history_more_details">More details</string>
+    <string name="quake_history_duration_value_format">%1$s seconds</string>
     <string name="quake_history_label_shakemap">Shakemap</string>
     <string name="quake_history_label_event_id">Event ID</string>
     <string name="quake_history_label_source">Source</string>


### PR DESCRIPTION
## Summary
- format quake history extra field values to append a localized seconds unit for duration entries
- add localized string resources for the seconds unit used by quake duration formatting

## Testing
- ⚠️ `./gradlew lint` *(fails: SDK location not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0317ffdf0832d8b36a9f4d4ce8471