### PR TITLE
Adjust bottom navigation styling for light mode

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -46,6 +46,10 @@
     </style>
 
     <style name="Widget.Quake.BottomNavigationView" parent="@style/Widget.MaterialComponents.BottomNavigationView">
+        <item name="android:background">@android:color/transparent</item>
+        <item name="android:backgroundTint">@android:color/transparent</item>
+        <item name="android:elevation">0dp</item>
+        <item name="android:stateListAnimator">@null</item>
         <item name="itemIconTint">@color/nav_item_color</item>
         <item name="itemTextColor">@color/nav_item_color</item>
         <item name="itemRippleColor">@color/sky_blue</item>


### PR DESCRIPTION
## Summary
- force the bottom navigation view background and tint to remain transparent in the shared style
- drop its default elevation animator so the light theme card background shows without stray dividers

## Testing
- `./gradlew lint` *(fails: missing Android SDK in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d139931480832dbfbdf75b8f8d2605