### PR TITLE
Parse geo: tags for quake coordinates and log to Logcat

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/msg/Message.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/Message.kt
@@ -14,6 +14,7 @@ data class Message(
     val topic: String,
     val priority: Int?,
     val tags: List<String>?,
+    @SerializedName("headers") val headers: Map<String, String>?,
     val click: String?,
     val icon: String?,
     val actions: List<MessageAction>?,

--- a/app/src/main/java/io/heckel/ntfy/msg/NotificationParser.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/NotificationParser.kt
@@ -9,6 +9,7 @@ import io.heckel.ntfy.db.Notification
 import io.heckel.ntfy.util.deriveNotificationId
 import io.heckel.ntfy.util.joinTags
 import io.heckel.ntfy.util.toPriority
+import io.heckel.ntfy.util.Log
 import java.lang.reflect.Type
 
 class NotificationParser {
@@ -26,6 +27,10 @@ class NotificationParser {
                 message.event == ApiService.EVENT_MESSAGE_CLEAR
         if (!validEvent) {
             return null
+        }
+        val geoLocation = geoLocationFromTags(message.tags)
+        if (geoLocation != null) {
+            Log.d(TAG, "Detected Quake from TAGS: ${geoLocation.latitude}, ${geoLocation.longitude}")
         }
         val attachment = if (message.attachment?.url != null) {
             Attachment(
@@ -77,6 +82,16 @@ class NotificationParser {
         return NotificationWithTopic(topic, notification)
     }
 
+    private fun geoLocationFromTags(tags: List<String>?): GeoLocation? {
+        val geoTag = tags?.firstOrNull { tag -> tag.startsWith(TAG_GEO_PREFIX, ignoreCase = true) } ?: return null
+        val coordinates = geoTag.substringAfter(TAG_GEO_PREFIX, missingDelimiterValue = "")
+        val (latitude, longitude) = coordinates.split(",", limit = 2).map { it.trim() }
+            .takeIf { it.size == 2 } ?: return null
+        val latitudeValue = latitude.toDoubleOrNull() ?: return null
+        val longitudeValue = longitude.toDoubleOrNull() ?: return null
+        return GeoLocation(latitudeValue, longitudeValue)
+    }
+
     /**
      * Parse JSON array to Action list. The indirection via MessageAction is probably
      * not necessary, but for "good form".
@@ -103,4 +118,11 @@ class NotificationParser {
     }
 
     data class NotificationWithTopic(val topic: String, val notification: Notification)
+
+    companion object {
+        private const val TAG = "QuakeAlert"
+        private const val TAG_GEO_PREFIX = "geo:"
+    }
+
+    private data class GeoLocation(val latitude: Double, val longitude: Double)
 }


### PR DESCRIPTION
### Motivation
- The server now includes earthquake coordinates in the message tags as `geo:LAT,LON`, so the client must extract coordinates from tags rather than headers. 
- Surface quake coordinates in Logcat for easier validation of backend-to-client delivery. 

### Description
- Update `NotificationParser.parseWithTopic` to extract a `GeoLocation` from message tags and log it via `Log.d(TAG, "Detected Quake from TAGS: ${geo.latitude}, ${geo.longitude}")` when present. 
- Add `geoLocationFromTags` helper that finds the first tag starting with `geo:`, parses the `LAT,LON` values, validates them as `Double`, and returns a private `GeoLocation` data class. 
- Introduce `TAG_GEO_PREFIX = "geo:"` constant and import the existing logging utility used by the project. 
- Changes applied to `app/src/main/java/io/heckel/ntfy/msg/NotificationParser.kt` (logging and parsing logic). 

### Testing
- No automated tests were executed for this change. 
- Manual validation was not recorded in automated test output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987131f0870832db4f04d8202ee259a)